### PR TITLE
Zanata nexus staging and branching

### DIFF
--- a/zanata-nexus-staging
+++ b/zanata-nexus-staging
@@ -12,6 +12,7 @@ SYNOPSIS
     zanata-nexus-staging-client    [options]
 
 OPTIONS
+    -h: Show this help
     -b: Bump the version in integration/master as well
         (e.g. when releasing from 3.7.X -> 3.8.0).
         If not specified, only the default branch will be touch
@@ -25,8 +26,23 @@ OPTIONS
 
 DESCRIPTION
     This program perform the release and push the relese with nexus.
-     
-	
+It can do following tasks:
+
+ * For making a X release (e.g. 3.Y.Z -> 4.0.0) or 
+   Y release: (e.g. 3.7.Z -> 3.8.0 ), run:
+
+   zanata-nexus-staging-<module> -b
+
+ * For making a Z release (e.g. 3.7.0 -> 3.7.1 ), run 
+
+   zanata-nexus-staging-<module>
+
+ * If tag is made but release failed, and you fixed it without changing 
+   the source, You can resume the release process with 
+  
+   zanata-nexus-staging-<module> -r
+
+
 ENVIRONMENT
     DEFAULT_BRANCH
       Branch is automatically determined by PROJECT.
@@ -63,8 +79,12 @@ EXIT_RELEASE_GOAL_FAIL=5
 BUMP_INTEGRATION_MASTER=
 SKIP_RELEASE_PLUGIN=
 
-while getopts "br" opt;do
+while getopts "brh" opt;do
     case $opt in
+	h )
+	    pring_usage
+	    exit 0
+	    ;;
         b )
 	    BUMP_INTEGRATION_MASTER=1
 	    ;;

--- a/zanata-nexus-staging
+++ b/zanata-nexus-staging
@@ -5,7 +5,7 @@ set -e
 function print_usage(){
     cat <<-END
 SYNOPSIS
-    zanata-nexus-staging [options] <PROJECT>
+    zanata-nexus-staging [options] <MODULE>
     zanata-nexus-staging-tennera   [options]
     zanata-nexus-staging-openprops [options]
     zanata-nexus-staging-parent    [options]
@@ -32,14 +32,18 @@ DESCRIPTION
     This program perform the release and push the relese with nexus.
 It can do following tasks:
 
- * For making a X release (e.g. 3.Y.Z -> 4.0.0) or 
-   Y release: (e.g. 3.7.Z -> 3.8.0 ), run:
+ * For making a big release (e.g. 3.Y.Z -> 4.0.0 or 3.7.Z -> 3.8.0 ), run:
 
    zanata-nexus-staging-<module> -b
+
+   It will commit to both RELEASING_BRANCH and DEVEL_BRANCH, see 
+   section ENVIRONMENT for details.
 
  * For making a Z release (e.g. 3.7.0 -> 3.7.1 ), run 
 
    zanata-nexus-staging-<module>
+
+   It will commit to RELEASING_BRANCH.
 
  * If tag is made but release failed, and you fixed it without changing 
    the source, You can resume the release process with 
@@ -48,9 +52,16 @@ It can do following tasks:
 
 
 ENVIRONMENT
-    DEFAULT_BRANCH
-      Branch is automatically determined by PROJECT.
-      Specify Environment DEFAULT_BRANCH to override.
+    RELEASING_BRANCH
+      The branch that release process should be working at. It is:
+         'release' if that branch branch exists; otherwise
+         'integration/master' if that branch exists; otherwise
+         'master'.
+ 
+    DEVEL_BRANCH 
+      The branch for new features. It is:
+         'integration/master' if that branch exists; otherwise
+         'master'.
 	
     WORK_ROOT
       The base directory for repository checkout
@@ -74,11 +85,11 @@ function echo_stderr(){
 }
 
 function ensure_repo(){
-    echo "### Ensure the repo $prj is at ${WORK_ROOT}/${prj}"
-    local prj=$1
-    local git_repo_url="git@github.com:zanata/${prj}.git"
+    local module=$1
+    echo "### Ensure the repo $module is at ${WORK_ROOT}/${module}"
+    local git_repo_url="git@github.com:zanata/${module}.git"
     pushd ${WORK_ROOT}
-    if [ ! -d ${prj} ];then
+    if [ ! -d ${module} ];then
         git clone ${git_repo_url}
         if [ $? -ne 0 ];then
 	    echo_stderr "[ERROR] Failed to clone ${git_repo_url}"
@@ -89,12 +100,12 @@ function ensure_repo(){
 }
 
 function does_branch_exist(){
-    local prj=$1
+    local module=$1
     local branch=$2
 
-    ensure_repo ${prj}
-    pushd ${WORK_ROOT}/${prj}
-    echo -n "### Does ${prj} has branch ${branch}?..."
+    ensure_repo ${module}
+    pushd ${WORK_ROOT}/${module}
+    echo -n "### Does ${module} has branch ${branch}?..."
 
     if git rev-parse --verify ${branch} &>/dev/null;then
         echo "yes" 
@@ -137,33 +148,33 @@ done
 
 shift $((OPTIND-1))
 if [ -n "$1" ];then
-    PROJECT="$1"
+    MODULE="$1"
 fi
 
 case $0 in
     *-tennera)
-	PROJECT=tennera
+	MODULE=tennera
         ;;
     *-openprops)
-	PROJECT=openprops
+	MODULE=openprops
 	;;
     *-parent)
-	PROJECT=zanata-parent
+	MODULE=zanata-parent
 	;;
     *-api)
-	PROJECT=zanata-api
+	MODULE=zanata-api
 	;;
     *-common)
-	PROJECT=zanata-common
+	MODULE=zanata-common
 	;;
     *-assets)
-	PROJECT=zanata-assets
+	MODULE=zanata-assets
 	;;
     *-client)
-	PROJECT=zanata-client
+	MODULE=zanata-client
 	;;
     *)
-	if [ -z "$PROJECT" ]; then
+	if [ -z "$MODULE" ]; then
 	    print_usage
 	    exit ${EXIT_INVALID_OPTIONS}
 	fi
@@ -174,58 +185,52 @@ if [ ! -d ${WORK_ROOT} ];then
     mkdir -p ${WORK_ROOT}
 fi
 
-### Determine DEFAULT_BRANCH
-if [ -z "${DEFAULT_BRANCH}" ];then
-    case ${PROJECT} in
-        tennera | openprops )
-	    DEFAULT_BRANCH=master
-            ;;
-        zanata-parent )
-	    DEFAULT_BRANCH=integration/master
-            ;;
-        * )
-	    DEFAULT_BRANCH=release
-            ;;
-    esac
+### Determine RELEASING_BRANCH
+
+if [ -z "${RELEASING_BRANCH}" ];then
+     if does_branch_exist ${MODULE} origin/release ;then
+         RELEASING_BRANCH=release
+     elif does_branch_exist ${MODULE} origin/integration/master ;then
+         RELEASING_BRANCH=integration/master
+     else
+         RELEASING_BRANCH=master
+    fi
 fi
-echo "### Releasing $PROJECT in branch ${DEFAULT_BRANCH}"
+echo "### RELEASING_BRANCH for $MODULE is ${RELEASING_BRANCH}"  
 
 ### Determine DEVEL_BRANCH, the branch the new feature developer 
 ### will normally submit. 
 ### DEVEL_BRANCH is integration/master if it exist, otherwise
 ### it is master
 
-if does_branch_exist ${PROJECT} origin/integration/master ;then
+if does_branch_exist ${MODULE} origin/integration/master ;then
     DEVEL_BRANCH=integration/master
 else
     DEVEL_BRANCH=master
 fi
-echo "### DEVEL_BRANCH for $PROJECT is ${DEVEL_BRANCH}"  
+echo "### DEVEL_BRANCH for $MODULE is ${DEVEL_BRANCH}"  
 
-cd ${WORK_ROOT}/${PROJECT}
+cd ${WORK_ROOT}/${MODULE}
 git fetch
 
-HAS_RELEASE_BRANCH=
-does_branch_exist ${PROJECT} origin/release && HAS_RELEASE_BRANCH=1
+echo "### [pre-release] ============================== Start"
+echo "### [pre-release] updating existing RELEASING_BRANCH (${RELEASING_BRANCH})"
+git checkout ${RELEASING_BRANCH}
 
-### Update existing release branch
-echo "### Pre-release: update existing release branchs"
-if [ -n "$HAS_RELEASE_BRANCH" ];then
-    git checkout release
+echo "### [pre-release] Branch ${RELEASING_BRANCH}: merge origin/${RELEASING_BRANCH}"
+git merge origin/${RELEASING_BRANCH} --ff-only --quiet
 
-    echo "### [pre-release] Branch release: merge origin/release"
-    git merge origin/release --ff-only --quiet
-    if [ -n "${BIG_RELEASE}" ];then
-        echo "### [pre-release] Branch release: merge origin/master as we do the big release"
-        git merge origin/master --ff-only --quiet
-    fi
-    echo "### [pre-release] Branch release: updated"
-    git push origin release
+if [ -n "${BIG_RELEASE}" -a "${RELEASING_BRANCH}" != "master" ];then
+    echo "### [pre-release] Branch ${RELEASING_BRANCH}: merge origin/master as we do the big release"
+    git merge origin/master --ff-only --quiet
+
+    echo "### [pre-release] Branch ${RELEASING_BRANCH}: pushing back to origin"
+    git push origin ${RELEASING_BRANCH}
 fi
 
 ### Update existing DEVEL_BRANCH on BIG_RELEASE
-echo "### Pre-release: update existing DEVEL_BRANCH (${DEVEL_BRANCH})"
 if [ -n "${BIG_RELEASE}" ]; then
+    echo "### Pre-release: update existing DEVEL_BRANCH (${DEVEL_BRANCH}) for big release"
     git checkout ${DEVEL_BRANCH}
 
     echo "### [pre-release] Branch ${DEVEL_BRANCH} merge origin/${DEVEL_BRANCH}"
@@ -234,22 +239,28 @@ if [ -n "${BIG_RELEASE}" ]; then
     echo "### [pre-release] Branch ${DEVEL_BRANCH}: Create new version"
     mvn -e release:update-versions -DautoVersionSubmodules=true
 
-    git commit pom.xml */pom.xml -m "prepare for next development iteration"
+    git commit $(find . -name 'pom.xml' | xargs ) -m "prepare for next development iteration"
     git push origin ${DEVEL_BRANCH}
     echo "### [pre-release] ${DEVEL_BRANCH} branch updated"
 fi
 
-### Release process
+echo "### [pre-release] back to RELEASING_BRANCH (${RELEASING_BRANCH})"
+git checkout ${RELEASING_BRANCH}
+git fetch --tags
+git pull
+
+echo "### [release] ============================== Start"
 function release_perform(){
     if [ -z "${SKIP_RELEASE_PLUGIN}" ];then
         git clean -f -d
 
-        ### Other projects might related to zanata-parent
-        if [ "$PROJECT" != "zanata-parent" ];then
+        ### Other MODULEs might related to zanata-parent
+        if [ "$MODULE" != "zanata-parent" ];then
              ensure_repo zanata-parent
         fi
         
-        echo "### [release_perform] Start: it should sign artifacts, push $PROJECT to nexus, then close it"
+        echo "### [release_perform] ============================== Start" 
+        echo "###it should sign artifacts, push $MODULE to nexus, then close it"
         mvn -e -Dmaven.repo.local=$REPO_LOCAL_DIR -Dgpg.useagent release:clean release:prepare release:perform
         if [ $? -ne 0 ];then
 	    echo_stderr "### [ERROR]: release goals failed"
@@ -260,12 +271,7 @@ function release_perform(){
     return 0
 }
 
-echo "### [release] Start"
-git checkout ${DEFAULT_BRANCH}
-git fetch --tags
-git pull
-
-case $PROJECT in
+case $MODULE in
     zanata-parent | zanata-api | zanata-common | zanata-assets )
 	release_perform
 
@@ -306,7 +312,7 @@ case $PROJECT in
 	;;
 
     * )
-	### Project like tennera or openprops
+	### MODULE like tennera or openprops
 	### These have only master
 	release_perform
 	mvn -e nexus-staging:close nexus-staging:release

--- a/zanata-nexus-staging
+++ b/zanata-nexus-staging
@@ -2,48 +2,45 @@
 
 function print_usage(){
     cat <<-END
-	== SYNOPSIS
-	zanata-nexus-staging [options] <PROJECT>
-	zanata-nexus-staging-tennera   [options]
-	zanata-nexus-staging-openprops [options]
-	zanata-nexus-staging-parent    [options]
-	zanata-nexus-staging-api       [options]
-	zanata-nexus-staging-common    [options]
+SYNOPSIS
+    zanata-nexus-staging [options] <PROJECT>
+    zanata-nexus-staging-tennera   [options]
+    zanata-nexus-staging-openprops [options]
+    zanata-nexus-staging-parent    [options]
+    zanata-nexus-staging-api       [options]
+    zanata-nexus-staging-common    [options]
+
+OPTIONS
+    -r: Skip release plugin
 	
-	== OPTIONS
-	-r: Skip release plugin
+Environment Variables
+  BRANCH
+    Branch is automatically determined by PROJECT.
+    Specify Environment BRANCH to override.
 	
-	== Environment Variables
+  WORK_ROOT
+    The base directory for repository checkout
+    As maven release plugin generally require a clean git working tree
+    This script will clean it for you.
+    Thus it is better not use normal working directory.
 	
-	=== BRANCH
-        Branch is automatically determined by PROJECT.
-        Specify Environment BRANCH to override.
+  REPO_LOCAL_DIR (Optional)
+    The directory for maven repo
+    This should NOT be your normal work maven repo
 	
-	=== WORK_ROOT
-	The base directory for repository checkout
-	As maven release plugin generally require a clean git working tree
-	This script will clean it for you.
-	Thus it is better not use normal working directory.
-	
-	=== REPO_LOCAL_DIR (Optional)
-	The directory for maven repo
-	This should NOT be your normal work maven repo
-	
-	=== EXIT_STATUS
-	EXIT_INVALID_OPTIONS=3
-	EXIT_FAIL_TO_CLONE=4
-	EXIT_RELEASE_GOAL_FAIL=5
-	END
+  EXIT_STATUS
+    EXIT_INVALID_OPTIONS=3
+    EXIT_FAIL_TO_CLONE=4
+    EXIT_RELEASE_GOAL_FAIL=5
+END
 }
 
 : ${WORK_ROOT:=/tmp/zanata}
 : ${REPO_LOCAL_DIR:=/tmp/maven-central-release-repo}
 
-
 EXIT_INVALID_OPTIONS=3
 EXIT_FAIL_TO_CLONE=4
 EXIT_RELEASE_GOAL_FAIL=5
-
 
 while getopts "r" opt;do
     case $opt in
@@ -183,5 +180,4 @@ case $PROJECT in
 	mvn -e nexus-staging:close nexus-staging:release
 	;;
 esac
-
 

--- a/zanata-nexus-staging
+++ b/zanata-nexus-staging
@@ -261,7 +261,7 @@ function release_perform(){
         
         echo "### [release_perform] ============================== Start" 
         echo "###it should sign artifacts, push $MODULE to nexus, then close it"
-        mvn -e -Dmaven.repo.local=$REPO_LOCAL_DIR -Dgpg.useagent release:clean release:prepare release:perform
+	mvn -e -Dmaven.repo.local=$REPO_LOCAL_DIR -Dgpg.useagent release:clean release:prepare release:perform -Psonatype-oss-release
         if [ $? -ne 0 ];then
 	    echo_stderr "### [ERROR]: release goals failed"
 	    exit ${EXIT_RELEASE_GOAL_FAIL}

--- a/zanata-nexus-staging
+++ b/zanata-nexus-staging
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 function print_usage(){
     cat <<-END
 SYNOPSIS
@@ -13,7 +15,8 @@ SYNOPSIS
 
 OPTIONS
     -h: Show this help
-    -b: Bump the version in integration/master as well
+    -b: Big release.
+        Integration/master need to be updated.
         (e.g. when releasing from 3.7.X -> 3.8.0).
         If not specified, only the default branch will be touch
         (e.g. when releasing from 3.7.0 -> 3.7.1 ).
@@ -69,6 +72,34 @@ function echo_stderr(){
     echo "$1" > /dev/stderr
 }
 
+function ensure_repo(){
+    echo "### Ensure the repo $prj is at ${WORK_ROOT}/${prj}"
+    local prj=$1
+    local git_repo_url="git@github.com:zanata/${prj}.git"
+    pushd ${WORK_ROOT}
+    if [ ! -d ${prj} ];then
+        git clone ${git_repo_url}
+        if [ $? -ne 0 ];then
+	    echo_stderr "[ERROR] Failed to clone ${git_repo_url}"
+	    exit ${EXIT_FAIL_TO_CLONE}
+       fi
+    fi
+    popd
+}
+
+function does_branch_exist(){
+    local prj=$1
+    local branch=$2
+    echo -n "### Does ${prj} has branch ${branch}?..."
+    if git rev-parse --verify ${branch} &>/dev/null;then
+        echo "yes" 
+        return 0
+    else
+        echo "no"
+        return 1 
+    fi
+}
+
 : ${WORK_ROOT:=/tmp/zanata}
 : ${REPO_LOCAL_DIR:=/tmp/maven-central-release-repo}
 
@@ -76,7 +107,7 @@ EXIT_INVALID_OPTIONS=3
 EXIT_FAIL_TO_CLONE=4
 EXIT_RELEASE_GOAL_FAIL=5
 
-BUMP_INTEGRATION_MASTER=
+BIG_RELEASE=
 SKIP_RELEASE_PLUGIN=
 
 while getopts "brh" opt;do
@@ -86,7 +117,7 @@ while getopts "brh" opt;do
 	    exit 0
 	    ;;
         b )
-	    BUMP_INTEGRATION_MASTER=1
+	    BIG_RELEASE=1
 	    ;;
 	r )
 	    SKIP_RELEASE_PLUGIN=1
@@ -144,73 +175,75 @@ if [ -z "${DEFAULT_BRANCH}" ];then
             ;;
     esac
 fi
-
-GIT_REPO_URL=git@github.com:zanata/${PROJECT}.git
+echo "### Releasing $PROJECT in branch ${DEFAULT_BRANCH}" 
 
 if [ ! -d ${WORK_ROOT} ];then
     mkdir -p ${WORK_ROOT}
 fi
 
-cd ${WORK_ROOT}
-if [ ! -d ${PROJECT} ];then
-    git clone ${GIT_REPO_URL}
-    if [ $? -ne 0 ];then
-	echo "[ERROR] Failed to clone ${GIT_REPO_URL}" >/dev/stderr
-	exit ${EXIT_FAIL_TO_CLONE}
-    fi
-fi
+ensure_repo ${PROJECT}
 
-cd ${PROJECT}
+cd ${WORK_ROOT}/${PROJECT}
 git fetch
 
-### Does it has release branch?
-if git rev-parse --verify origin/release ;then
-    HAS_RELEASE_BRANCH=1
-else
-    HAS_RELEASE_BRANCH=
-fi
+HAS_RELEASE_BRANCH=
+does_branch_exist ${PROJECT} origin/release && HAS_RELEASE_BRANCH=1
 
-### Does it has integration/master branch?
-if git rev-parse --verify origin/integration/master ;then
-    HAS_INTEGRATION_MASTER_BRANCH=1
-else
-    HAS_INTEGRATION_MASTER_BRANCH=
-fi
+HAS_INTEGRATION_MASTER_BRANCH=
+does_branch_exist ${PROJECT} origin/integration/master && 
+HAS_INTEGRATION_MASTER_BRANCH=1
 
-### Update release branch if it it exists
+### Update existing release branch
+echo "### Pre-release: update existing release branchs"
 if [ -n "$HAS_RELEASE_BRANCH" ];then
-    echo_stderr "[pre-release] Updating release branch"
     git checkout release
+
+    echo "### [pre-release] Branch release: merge origin/release"
     git merge origin/release --ff-only --quiet
-    git merge origin/master --ff-only --quiet
-    echo_stderr "[pre-release] release branch updated"
+    if [ -n "${BIG_RELEASE}" ];then
+        echo "### [pre-release] Branch release: merge origin/master as we do the big release"
+        git merge origin/master --ff-only --quiet
+    fi
+    echo "### [pre-release] Branch release: updated"
+    git push origin release
 fi
 
-### Update integration/master branch if it exists
-if [ -n "${BUMP_INTEGRATION_MASTER}" -a -n "$HAS_INTEGRATION_MASTER_BRANCH" ];then
-    echo_stderr "[pre-release] Updating integration/master branch"
+### Update existing integration/master branch on BIG_RELEASE
+echo "### Pre-release: update existing integration/master branchs"
+if [ -n "${BIG_RELEASE}" -a -n "$HAS_INTEGRATION_MASTER_BRANCH" ];then
     git checkout integration/master
+
+    echo "### [pre-release] Branch integration/master merge origin/integration/master"
     git merge origin/integration/master --ff-only --quiet
+
+    echo "### [pre-release] Branch integration/master: Create new version"
     mvn -e release:update-versions -DautoVersionSubmodules=true
+
     git commit pom.xml */pom.xml -m "prepare for next development iteration"
     git push origin integration/master
-    echo_stderr "[pre-release] integration/master branch updated"
+    echo "### [pre-release] integration/master branch updated"
 fi
 
 ### Release process
 function release_perform(){
     if [ -z "${SKIP_RELEASE_PLUGIN}" ];then
         git clean -f -d
+        if [ "$PROJECT" != "zanata-parent" ];then
+             ensure_repo zanata-parent
+        fi
+        
+        echo "### [release_perform] Start"
         mvn -e -Dmaven.repo.local=$REPO_LOCAL_DIR -Dgpg.useagent release:clean release:prepare release:perform
         if [ $? -ne 0 ];then
-	    echo_stderr "[ERROR]: release goals failed"
+	    echo_stderr "### [ERROR]: release goals failed"
 	    exit ${EXIT_RELEASE_GOAL_FAIL}
         fi
     fi
+    echo "### [release_perform] Done"
     return 0
 }
 
-echo_stderr "### Start release process"
+echo "### [release] Start"
 git checkout ${DEFAULT_BRANCH}
 git fetch --tags
 git pull
@@ -219,6 +252,8 @@ case $PROJECT in
     zanata-parent | zanata-api | zanata-common )
 	### zanata-parent has only master
 	release_perform
+
+        echo "### [release] nexus-staging:release"
 	mvn -e nexus-staging:release -Psonatype-oss-release \
 	    -DstagingRepositoryId=$(grep -oP '^stagingRepository\.id=\K.*' target/checkout/target/nexus-staging/staging/*.properties)
 	;;
@@ -228,6 +263,7 @@ case $PROJECT in
 	release_perform
 
         ### Create and sign the artifacts
+        echo "### [release] Create and sign the artifacts"
 	mvn -e clean deploy source:jar javadoc:jar jar:jar gpg:sign -Dgpg.useagent -DskipTests=true -DskipArqTests=true -Dfindbugs.skip=true 
 
 	### make bundles for each submodules:

--- a/zanata-nexus-staging
+++ b/zanata-nexus-staging
@@ -9,30 +9,48 @@ SYNOPSIS
     zanata-nexus-staging-parent    [options]
     zanata-nexus-staging-api       [options]
     zanata-nexus-staging-common    [options]
+    zanata-nexus-staging-client    [options]
 
 OPTIONS
+    -b: Bump the version in integration/master as well
+        (e.g. when releasing from 3.7.X -> 3.8.0).
+        If not specified, only the default branch will be touch
+        (e.g. when releasing from 3.7.0 -> 3.7.1 ).
+	Default branch is:
+	  release if it has release; otherwise
+	  integration/master if it has release; otherwise
+	  master.
+
     -r: Skip release plugin
+
+DESCRIPTION
+    This program perform the release and push the relese with nexus.
+     
 	
-Environment Variables
-  BRANCH
-    Branch is automatically determined by PROJECT.
-    Specify Environment BRANCH to override.
+ENVIRONMENT
+    DEFAULT_BRANCH
+      Branch is automatically determined by PROJECT.
+      Specify Environment DEFAULT_BRANCH to override.
 	
-  WORK_ROOT
-    The base directory for repository checkout
-    As maven release plugin generally require a clean git working tree
-    This script will clean it for you.
-    Thus it is better not use normal working directory.
+    WORK_ROOT
+      The base directory for repository checkout
+      As maven release plugin generally require a clean git working tree
+      This script will clean it for you.
+      Thus it is better not use normal working directory.
 	
-  REPO_LOCAL_DIR (Optional)
-    The directory for maven repo
-    This should NOT be your normal work maven repo
+    REPO_LOCAL_DIR (Optional)
+      The directory for maven repo
+      This should NOT be your normal work maven repo
 	
-  EXIT_STATUS
+EXIT_STATUS
     EXIT_INVALID_OPTIONS=3
     EXIT_FAIL_TO_CLONE=4
     EXIT_RELEASE_GOAL_FAIL=5
 END
+}
+
+function echo_stderr(){
+    echo "$1" > /dev/stderr
 }
 
 : ${WORK_ROOT:=/tmp/zanata}
@@ -42,8 +60,14 @@ EXIT_INVALID_OPTIONS=3
 EXIT_FAIL_TO_CLONE=4
 EXIT_RELEASE_GOAL_FAIL=5
 
-while getopts "r" opt;do
+BUMP_INTEGRATION_MASTER=
+SKIP_RELEASE_PLUGIN=
+
+while getopts "br" opt;do
     case $opt in
+        b )
+	    BUMP_INTEGRATION_MASTER=1
+	    ;;
 	r )
 	    SKIP_RELEASE_PLUGIN=1
 	    ;;
@@ -87,16 +111,16 @@ case $0 in
 esac
 
 ### Set default branches
-if [ -z "${BRANCH}" ];then
+if [ -z "${DEFAULT_BRANCH}" ];then
     case ${PROJECT} in
         tennera | openprops )
-	    BRANCH=master
+	    DEFAULT_BRANCH=master
             ;;
         zanata-parent )
-	    BRANCH=integration/master
+	    DEFAULT_BRANCH=integration/master
             ;;
         zanata-api | zanata-common | zanata-client)
-	    BRANCH=release
+	    DEFAULT_BRANCH=release
             ;;
     esac
 fi
@@ -117,28 +141,64 @@ if [ ! -d ${PROJECT} ];then
 fi
 
 cd ${PROJECT}
-git checkout $BRANCH
-git pull
+git fetch
 
-###== release_perform
-### Do the step required by maven release plugin
+### Does it has release branch?
+if git rev-parse --verify origin/release ;then
+    HAS_RELEASE_BRANCH=1
+else
+    HAS_RELEASE_BRANCH=
+fi
+
+### Does it has integration/master branch?
+if git rev-parse --verify origin/integration/master ;then
+    HAS_INTEGRATION_MASTER_BRANCH=1
+else
+    HAS_INTEGRATION_MASTER_BRANCH=
+fi
+
+### Update release branch if it it exists
+if [ -n "$HAS_RELEASE_BRANCH" ];then
+    echo_stderr "[pre-release] Updating release branch"
+    git checkout release
+    git merge origin/release --ff-only --quiet
+    git merge origin/master --ff-only --quiet
+    echo_stderr "[pre-release] release branch updated"
+fi
+
+### Update integration/master branch if it exists
+if [ -n "${BUMP_INTEGRATION_MASTER}" -a -n "$HAS_INTEGRATION_MASTER_BRANCH" ];then
+    echo_stderr "[pre-release] Updating integration/master branch"
+    git checkout integration/master
+    git merge origin/integration/master --ff-only --quiet
+    mvn -e release:update-versions -DautoVersionSubmodules=true
+    git commit pom.xml */pom.xml -m "prepare for next development iteration"
+    git push origin integration/master
+    echo_stderr "[pre-release] integration/master branch updated"
+fi
+
+### Release process
 function release_perform(){
     if [ -z "${SKIP_RELEASE_PLUGIN}" ];then
-	git clean -f -d
-	mvn -e -Dmaven.repo.local=$REPO_LOCAL_DIR -Dgpg.useagent release:clean release:prepare release:perform
-	if [ $? -ne 0 ];then
-	    echo "[ERROR]: release goals failed" >/dev/stderr
+        git clean -f -d
+        mvn -e -Dmaven.repo.local=$REPO_LOCAL_DIR -Dgpg.useagent release:clean release:prepare release:perform
+        if [ $? -ne 0 ];then
+	    echo_stderr "[ERROR]: release goals failed"
 	    exit ${EXIT_RELEASE_GOAL_FAIL}
-	fi
+        fi
     fi
     return 0
 }
+
+echo_stderr "### Start release process"
+git checkout ${DEFAULT_BRANCH}
+git fetch --tags
+git pull
 
 case $PROJECT in
     zanata-parent | zanata-api | zanata-common )
 	### zanata-parent has only master
 	release_perform
-#	mvn -e nexus-staging:close nexus-staging:release -
 	mvn -e nexus-staging:release -Psonatype-oss-release \
 	    -DstagingRepositoryId=$(grep -oP '^stagingRepository\.id=\K.*' target/checkout/target/nexus-staging/staging/*.properties)
 	;;

--- a/zanata-nexus-staging
+++ b/zanata-nexus-staging
@@ -16,8 +16,8 @@ function print_usage(){
 	== Environment Variables
 	
 	=== BRANCH
-	We assume to work on release branch
-	Specify BRANCH=integration/master  if you want integration/master instead
+        Branch is automatically determined by PROJECT.
+        Specify Environment BRANCH to override.
 	
 	=== WORK_ROOT
 	The base directory for repository checkout
@@ -36,9 +36,9 @@ function print_usage(){
 	END
 }
 
-: ${BRANCH:=release}
 : ${WORK_ROOT:=/tmp/zanata}
 : ${REPO_LOCAL_DIR:=/tmp/maven-central-release-repo}
+
 
 EXIT_INVALID_OPTIONS=3
 EXIT_FAIL_TO_CLONE=4
@@ -89,6 +89,21 @@ case $0 in
 	;;
 esac
 
+### Set default branches
+if [ -z "${BRANCH}" ];then
+    case ${PROJECT} in
+        tennera | openprops )
+	    BRANCH=master
+            ;;
+        zanata-parent )
+	    BRANCH=integration/master
+            ;;
+        zanata-api | zanata-common | zanata-client)
+	    BRANCH=release
+            ;;
+    esac
+fi
+
 GIT_REPO_URL=git@github.com:zanata/${PROJECT}.git
 
 if [ ! -d ${WORK_ROOT} ];then
@@ -105,6 +120,7 @@ if [ ! -d ${PROJECT} ];then
 fi
 
 cd ${PROJECT}
+git checkout $BRANCH
 git pull
 
 ###== release_perform
@@ -112,7 +128,7 @@ git pull
 function release_perform(){
     if [ -z "${SKIP_RELEASE_PLUGIN}" ];then
 	git clean -f -d
-	mvn -Dmaven.repo.local=$REPO_LOCAL_DIR -Dgpg.useagent release:clean release:prepare release:perform
+	mvn -e -Dmaven.repo.local=$REPO_LOCAL_DIR -Dgpg.useagent release:clean release:prepare release:perform
 	if [ $? -ne 0 ];then
 	    echo "[ERROR]: release goals failed" >/dev/stderr
 	    exit ${EXIT_RELEASE_GOAL_FAIL}
@@ -124,21 +140,18 @@ function release_perform(){
 case $PROJECT in
     zanata-parent | zanata-api | zanata-common )
 	### zanata-parent has only master
-	if [ "${PROJECT}" != "zanata-parent" ];then
-	    git checkout $BRANCH
-	fi
 	release_perform
-	mvn nexus-staging:close nexus-staging:release -Psonatype-oss-release \
+#	mvn -e nexus-staging:close nexus-staging:release -
+	mvn -e nexus-staging:release -Psonatype-oss-release \
 	    -DstagingRepositoryId=$(grep -oP '^stagingRepository\.id=\K.*' target/checkout/target/nexus-staging/staging/*.properties)
 	;;
     zanata-client )
 	### auto nexus-staging does not seem to work with zanata-client
 	### Need to use manual bundle jars
-	git checkout $BRANCH
 	release_perform
 
         ### Create and sign the artifacts
-	mvn clean deploy source:jar javadoc:jar jar:jar gpg:sign -Dgpg.useagent -DskipTests=true -DskipArqTests=true -Dfindbugs.skip=true 
+	mvn -e clean deploy source:jar javadoc:jar jar:jar gpg:sign -Dgpg.useagent -DskipTests=true -DskipArqTests=true -Dfindbugs.skip=true 
 
 	### make bundles for each submodules:
 	SUBMODULES=(. zanata-cli zanata-client-commands zanata-maven-plugin zanata-rest-client)
@@ -167,7 +180,7 @@ case $PROJECT in
 	### Project like tennera or openprops
 	### These have only master
 	release_perform
-	mvn nexus-staging:close nexus-staging:release
+	mvn -e nexus-staging:close nexus-staging:release
 	;;
 esac
 


### PR DESCRIPTION
1. Usage: Looks more like man-page.
2. Integrate the release branching process.
   a.  For Y release like 3.7 -> 3.8, you can specify option `-b` so the `integration-master` branch version can be bumped as well.
   b. No longer need to manually change and specify branch.
