### PR TITLE
feat(ZNTA-1165): Script to upload files to GitHub release

### DIFF
--- a/ZanataScriptsCommon.pm
+++ b/ZanataScriptsCommon.pm
@@ -58,10 +58,18 @@ sub rest_response {
     return $userAgent->request( $request, $contentCb, $readSizeHint );
 }
 
+## Exit code
 sub response_die_if_error {
     my ( $response, $prompt ) = @_;
-    die $prompt . " Code: " . $response->code . "  Message: " . $response->message
-      unless ( $response->is_success );
+    unless ( $response->is_success ) {
+        my ( $package, $filename, $line ) = caller;
+        die $prompt
+          . " Code: "
+          . $response->code
+          . "  Message: "
+          . $response->message . "\n"
+          . "  at $package::$filename, line $line\n";
+    }
 }
 
 my %zanataScriptsIniHash;

--- a/zanata-github-upload
+++ b/zanata-github-upload
@@ -36,7 +36,7 @@ Show complete help.
 
 Create a new draft GitHub release.
 This program does not find existing draft release,
-so run this program multiple times creates multiple draft releases.
+so running this program multiple times creates multiple draft releases.
 
 =item B<-v>
 
@@ -133,6 +133,9 @@ my $module = `$scriptDir/zanata-functions run get_module $artifact`;
 chomp($module);
 print STDERR "module=$module\n" if $verbose;
 shift;
+die "Invalid releaseTag $releaseTag. \n"
+    . "  Valid releaseTag looks like server-4.0.0 or client-4.0.0"
+	if ($module eq '-');
 
 ## Check whether the files are readable.
 foreach my $f (@ARGV) {

--- a/zanata-github-upload
+++ b/zanata-github-upload
@@ -1,0 +1,202 @@
+#!/usr/bin/env perl
+
+=pod
+
+=head1 NAME
+
+zanata-github-upload - Upload files to GitHub
+
+=head1 SYNOPSIS
+
+zanata-github-upload [Option] E<lt>releaseTagE<gt> E<lt>fileE<gt> ...
+
+=head1 ARGUMENTS
+
+=over 4
+
+=item E<lt>releaseTagE<gt>
+
+Destintation release tag like C<server-4.0.0>
+
+=item <file> ...
+
+Files to be uploaded.
+
+=back
+
+=head1 OPTIONS
+
+=over 4
+
+=item B<-h>
+
+Show complete help
+
+=item B<-d>
+
+Create a draft GitHub release
+
+=item B<-v>
+
+Verbose mode.
+
+=back
+
+=head1 DESCRIPTION
+
+This program upload the files to GitHub release.
+It will create the release if it does not exists,
+then upload files to GitHub release.
+
+You can try this program by creating draft release.
+Specify option C<-d> to create draft release.
+
+GitHub credential is required for uploading so this program loads
+the GitHub credential from ${HOME}/.config/zanata-scripts.ini.
+The format is explained in section FILES. 
+
+=head1 FILES
+
+=over 4
+
+=item ${HOME}/.config/zanata-scripts.ini
+
+This file configures the zanata-scripts, including the GitHub credentials.
+
+The format looks like:
+
+    github_username=<USERNAME>
+    github_token=<TOKEN>
+
+As this file is plain text, use an access token instead of login password.
+To get an access token, see:
+https://help.github.com/articles/creating-an-access-token-for-command-line-use/
+
+=back
+
+=cut
+
+#== Common use ==
+use strict;
+use Cwd 'abs_path';
+use Data::Dumper qw(Dumper);
+use File::Basename;
+use Getopt::Std qw(getopts);
+use Pod::Usage qw(pod2usage);
+
+my $scriptDir;
+
+BEGIN {
+    $scriptDir = dirname( abs_path($0) );
+    push @INC, $scriptDir;
+}
+use ZanataScriptsCommon;
+
+##== Program dependency ==
+use File::Slurp;
+use HTTP::Tiny;
+use JSON::XS;
+use URI::Escape;
+$HTTP::Request::Common::DYNAMIC_FILE_UPLOAD = 1;
+
+##== Parse options ==
+my %opts = ();
+getopts( 'hdv', \%opts );
+my $verbose = ( exists $opts{'v'} ) ? 1 : 0;
+
+pod2usage( -verbose => 3, -output => \*STDERR ) if $opts{'h'};
+if ( @ARGV < 2 ) {
+    pod2usage(
+        -verbose => 1,
+        -output  => \*STDERR,
+        -exitval => EXIT_FATAL_INVALID_OPTIONS,
+        -message => "Require <releaseTag> and <file> ... \n"
+    );
+}
+my $releaseTag = $ARGV[0];
+my ($artifact) = split( /-/, $releaseTag, 2 );
+my $module = `$scriptDir/zanata-functions run get_module $artifact`;
+chomp($module);
+print STDERR "module=$module\n" if $verbose;
+shift;
+
+## Check whether the files are readable.
+foreach my $f (@ARGV) {
+    die "$f is not readable. $!" unless ( -r $f );
+}
+
+##== Create Release ==
+print_status( "Create Release", "Start", 's' );
+my $response = github_logined_rest_response( 'GET',
+    "/repos/zanata/$module/releases/tags/$releaseTag" );
+print STDERR Dumper($response) if $verbose;
+my $uploadUrl = undef;
+
+if ( $response->code == 200 ) {
+    ##=== Release Already created ===
+    print_status( '', "Release $releaseTag already created.", '' );
+    my $contentHRef = decode_json $response->content;
+    $uploadUrl = $contentHRef->{'upload_url'};
+}
+elsif ( $response->code == 404 ) {
+    ##=== Creating new release ===
+    print_status( '', "Creating release $releaseTag", '' );
+    my $draft = ( exists $opts{'d'} ) ? 'true' : 'false';
+    $response = github_logined_rest_response(
+        'POST',
+        "/repos/zanata/$module/releases",
+        [
+            Accept         => 'application/json',
+            'Content-Type' => 'application/json'
+        ],
+        qq({
+            "tag_name": "$releaseTag",
+            "draft": $draft,
+            "prerelease": false
+        })
+    );
+    print STDERR Dumper($response) if $verbose;
+    my $contentHRef = decode_json $response->content;
+    $uploadUrl = $contentHRef->{'upload_url'};
+    response_die_if_error( $response, "Failed to create release." );
+}
+else {
+    response_die_if_error( $response, "Failed to query release." );
+}
+
+##== Upload ==
+print_status( "Upload", "Start", 's' );
+$uploadUrl =~ s/^(http.*\/releases\/[0-9]+\/assets).*$/$1/;
+my ( $uploadProtocal, $uploadPath ) = split( /:\/\//, $uploadUrl, 2 );
+print_status( undef, " protocal=$uploadProtocal  path=$uploadPath" )
+  if $verbose;
+
+## Previous responseed upload_url is required to upload
+sub github_upload {
+    my ( $filePath, $label ) = @_;
+    my $name = basename($filePath);
+    my $content = read_file( $filePath, binmode => ':raw' );
+
+    github_credential_has_value;
+
+    my $url =
+        $uploadProtocal . "://"
+      . zanata_scripts_ini_key_get_value('github_username') . ':'
+      . zanata_scripts_ini_key_get_value('github_token') . '@'
+      . $uploadPath
+      . "?name="
+      . uri_escape($name);
+    $url .= "&label=" . uri_escape($label) if ($label);
+    my @cmd =
+		qw( curl -i -o /tmp/request.txt -X POST);
+	push @cmd,  '-H', 'Content-Type: application/octet-stream';
+	push @cmd, '--data-binary', "@" . $filePath , $url;
+    system(@cmd) == 0
+      or die "system @cmd failed: $?";
+}
+
+foreach my $f (@ARGV) {
+    print_status( undef, " Uploading $f" );
+    github_upload($f);
+}
+

--- a/zanata-github-upload
+++ b/zanata-github-upload
@@ -20,7 +20,7 @@ Destintation release tag like C<server-4.0.0>
 
 =item <file> ...
 
-Files to be uploaded.
+Files to be uploaded. Separate multiple files with spaces.
 
 =back
 
@@ -30,30 +30,41 @@ Files to be uploaded.
 
 =item B<-h>
 
-Show complete help
+Show complete help.
 
 =item B<-d>
 
-Create a draft GitHub release
+Create a new draft GitHub release.
+This program does not find existing draft release,
+so run this program multiple times creates multiple draft releases.
 
 =item B<-v>
 
 Verbose mode.
+This shows detail debuge messages like which module it is processing,
+and full HTTP responde structure.
 
 =back
 
 =head1 DESCRIPTION
 
-This program upload the files to GitHub release.
+This program uploads the files to GitHub release.
 It will create the release if it does not exists,
 then upload files to GitHub release.
 
-You can try this program by creating draft release.
+Before uploading, the release tag (e.g. server-4.0.0) should exist,
+otherwise it prints error.
+
+You can try this program by creating draft releases.
 Specify option C<-d> to create draft release.
 
-GitHub credential is required for uploading so this program loads
-the GitHub credential from ${HOME}/.config/zanata-scripts.ini.
-The format is explained in section FILES. 
+GitHub credentials are required for uploading so this program loads
+the GitHub credentials in ${HOME}/.config/zanata-scripts.ini.
+The format is explained in section FILES.
+
+Note that this program does not yet find existing draft releases,
+so you need to login GitHub Web UI to remove drafts or promote drafts as
+real releases.
 
 =head1 FILES
 
@@ -115,6 +126,9 @@ if ( @ARGV < 2 ) {
 }
 my $releaseTag = $ARGV[0];
 my ($artifact) = split( /-/, $releaseTag, 2 );
+
+## module is actually GitHub repository
+## such as zanata-parent, zanata-server
 my $module = `$scriptDir/zanata-functions run get_module $artifact`;
 chomp($module);
 print STDERR "module=$module\n" if $verbose;
@@ -125,9 +139,15 @@ foreach my $f (@ARGV) {
     die "$f is not readable. $!" unless ( -r $f );
 }
 
+##== Check Existing Tags ==
+my $response = github_rest_response( 'GET',
+    "/repos/zanata/$module/git/refs/tags/$releaseTag" );
+print STDERR Dumper($response) if $verbose;
+response_die_if_error( $response, "Tag $releaseTag does not exists." );
+
 ##== Create Release ==
 print_status( "Create Release", "Start", 's' );
-my $response = github_logined_rest_response( 'GET',
+$response = github_logined_rest_response( 'GET',
     "/repos/zanata/$module/releases/tags/$releaseTag" );
 print STDERR Dumper($response) if $verbose;
 my $uploadUrl = undef;
@@ -167,11 +187,13 @@ else {
 ##== Upload ==
 print_status( "Upload", "Start", 's' );
 $uploadUrl =~ s/^(http.*\/releases\/[0-9]+\/assets).*$/$1/;
-my ( $uploadProtocal, $uploadPath ) = split( /:\/\//, $uploadUrl, 2 );
-print_status( undef, " protocal=$uploadProtocal  path=$uploadPath" )
+my ( $uploadProtocol, $uploadPath ) = split( /:\/\//, $uploadUrl, 2 );
+print_status( undef, " protocol=$uploadProtocol  path=$uploadPath" )
   if $verbose;
 
-## Previous responseed upload_url is required to upload
+## github_upload(<filePath>, [label])
+##    filePath: Location of the file to be upload
+##    label: (Optional) GitHub release label
 sub github_upload {
     my ( $filePath, $label ) = @_;
     my $name = basename($filePath);
@@ -180,17 +202,16 @@ sub github_upload {
     github_credential_has_value;
 
     my $url =
-        $uploadProtocal . "://"
+        $uploadProtocol . "://"
       . zanata_scripts_ini_key_get_value('github_username') . ':'
       . zanata_scripts_ini_key_get_value('github_token') . '@'
       . $uploadPath
       . "?name="
       . uri_escape($name);
     $url .= "&label=" . uri_escape($label) if ($label);
-    my @cmd =
-		qw( curl -i -o /tmp/request.txt -X POST);
-	push @cmd,  '-H', 'Content-Type: application/octet-stream';
-	push @cmd, '--data-binary', "@" . $filePath , $url;
+    my @cmd = qw( curl -i -o /tmp/request.txt -X POST);
+    push @cmd, '-H', 'Content-Type: application/octet-stream';
+    push @cmd, '--data-binary', "@" . $filePath, $url;
     system(@cmd) == 0
       or die "system @cmd failed: $?";
 }

--- a/zanata-overlay-build
+++ b/zanata-overlay-build
@@ -88,7 +88,12 @@ while getopts "haw:" opt;do
 	    AutoDetect=1
 	    ;;
 	w )
-	    War=$OPTARG
+	    if [[ $OPTARG =~ ^/ ]]; then
+		War=$OPTARG
+	    else
+		War=$PWD/$OPTARG
+	    fi
+
 	    ;;
 	* )
 	    failed ${EXIT_FATAL_INVALID_OPTIONS} "$opt"

--- a/zanata-package-fedora
+++ b/zanata-package-fedora
@@ -72,8 +72,8 @@ function is_branch_build_in_koji(){
     print_status -n " koji: is ${pkgBuild} in? ... "
 
     if koji buildinfo $pkgBuild | grep -qcs -i "State: COMPLETE" ;then
-	print_status "yes, skip"
-	return 0
+        print_status "yes, skip"
+        return 0
     fi
     print_status "no, will submit it"
     return 1
@@ -87,7 +87,7 @@ function is_branch_build_in_bodhi(){
     local pkgBuild="$Nvr.${bodhiBranch}"
     print_status -n " bodhi: is ${pkgBuild} in? ... "
     if bodhi "${pkgBuild}" | grep -qcs -i "Submit" > /dev/null;then
-	print_status "yes, skip"
+        print_status "yes, skip"
     fi
     print_status "no, will submit it"
     return 1
@@ -103,16 +103,16 @@ SpecRelease=
 AutoDetect=0
 while getopts "ha" opt;do
     case $opt in
-	h )
-	    zanata_script_help $0
-	    exit ${EXIT_OK}
-	    ;;
-	a )
-	    AutoDetect=1
-	    ;;
-	* )
-	    exit_if_failed ${EXIT_FATAL_INVALID_OPTIONS} ${EXIT_FATAL_INVALID_OPTIONS} "$opt"
-	    ;;
+        h )
+            zanata_script_help $0
+            exit ${EXIT_OK}
+            ;;
+        a )
+            AutoDetect=1
+            ;;
+        * )
+            exit_if_failed ${EXIT_FATAL_INVALID_OPTIONS} ${EXIT_FATAL_INVALID_OPTIONS} "$opt"
+            ;;
     esac
 done
 shift $((OPTIND-1))
@@ -128,9 +128,9 @@ print_status " Module=$Module"
 ## Get Version
 if [ ${AutoDetect} -eq 0 ];then
     if [ -z "${1-}" ];then
-	zanata_script_help $0
-	EXIT_MSG="Requires version-release. Please either specify version-release or use option -a"
-	exit ${EXIT_FATAL_INVALID_OPTIONS}
+        zanata_script_help $0
+        EXIT_MSG="Requires version-release. Please either specify version-release or use option -a"
+        exit ${EXIT_FATAL_INVALID_OPTIONS}
     fi
     VersionRelease=$1
 
@@ -200,7 +200,7 @@ cmake-fedora-fedpkg $Srpm fedora
 if [ $Module != "zanata-server" ];then
     print_status -t "Buildroot Override" -s "Start"
     for bodhiBranch in $(cmake-fedora-koji bodhi-branch fedora | xargs );do
-	bodhi --buildroot-override $Module-$Version-$SpecRelease.$bodhiBranch
+        bodhi --buildroot-override $Module-$Version-$SpecRelease.$bodhiBranch
     done
     bodhi --buildroot-override 
 fi

--- a/zanata-package-fedora
+++ b/zanata-package-fedora
@@ -196,3 +196,12 @@ exit_if_failed $? $EXIT_FATAL_FAIL " Failed to create SRPM $Srpm"
 print_status -t "Build" -s "Start"
 cmake-fedora-fedpkg $Srpm fedora
 
+##=== Buildroot Override ===
+if [ $Module != "zanata-server" ];then
+    print_status -t "Buildroot Override" -s "Start"
+    for bodhiBranch in $(cmake-fedora-koji bodhi-branch fedora | xargs );do
+	bodhi --buildroot-override $Module-$Version-$SpecRelease.$bodhiBranch
+    done
+    bodhi --buildroot-override 
+fi
+


### PR DESCRIPTION
Brief usage:
- zanata-github-upload -h
     Show detailed help
- zanata-github-upload -dv server-3.9.1 &lt;PATH&gt;/zanata-war-3.9.1.war
     `-d`: Draft release, `-v`:Verbose mode that prints debug message like HTTP response
     It will create a 'draft' server-3.9.1 release,  upload &lt;PATH&gt;/zanata-war-3.9.1.war,
    and show debug message.
- zanata-github-upload server-3.9.1 &lt;PATH&gt;/zanata-war-3.9.1.war
     It will create the 'real' server-3.9.1 release (if not already exists), then upload &lt;PATH&gt;/zanata-war-3.9.1.war to server-3.9.1

Setup:
     You need to create ~/.config/zanata-scripts.ini and put your github username and token (NOT YOUR PASSWORD). Detail should be explained in FILE section in `zanata-github-upload -h`

Test tip:
 Find the tags that do not have release, e.g. tag before server-3.6.0. `zanata-github-upload` does not check what file it upload.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-scripts/7)

<!-- Reviewable:end -->
